### PR TITLE
Add modular calculator services with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# test_codex_config
+# Calculator Microservices
+
+This repository contains a modular calculator implemented in Python. The calculator is split into separate modules that mirror a microservice architecture:
+
+- `calculator/algebra.py`: basic algebraic operations and trigonometric functions.
+- `calculator/integration.py`: numerical integration using the trapezoidal rule.
+- `calculator/plotting.py`: plotting of functions using `matplotlib`.
+
+Unit tests for each module are located in the `tests/` directory.

--- a/calculator/__init__.py
+++ b/calculator/__init__.py
@@ -1,0 +1,17 @@
+"""Calculator package containing modules for algebra, integration, and plotting."""
+
+from .algebra import add, subtract, multiply, divide, sin, cos, tan
+from .integration import integrate
+from .plotting import plot_function
+
+__all__ = [
+    "add",
+    "subtract",
+    "multiply",
+    "divide",
+    "sin",
+    "cos",
+    "tan",
+    "integrate",
+    "plot_function",
+]

--- a/calculator/algebra.py
+++ b/calculator/algebra.py
@@ -1,0 +1,37 @@
+"""Algebra and trigonometry operations."""
+
+import math
+
+def add(a: float, b: float) -> float:
+    """Return the sum of *a* and *b*."""
+    return a + b
+
+def subtract(a: float, b: float) -> float:
+    """Return the difference of *a* and *b*."""
+    return a - b
+
+def multiply(a: float, b: float) -> float:
+    """Return the product of *a* and *b*."""
+    return a * b
+
+def divide(a: float, b: float) -> float:
+    """Return *a* divided by *b*.
+
+    Raises:
+        ValueError: If *b* is zero.
+    """
+    if b == 0:
+        raise ValueError("Division by zero is undefined")
+    return a / b
+
+def sin(x: float) -> float:
+    """Return the sine of *x* (in radians)."""
+    return math.sin(x)
+
+def cos(x: float) -> float:
+    """Return the cosine of *x* (in radians)."""
+    return math.cos(x)
+
+def tan(x: float) -> float:
+    """Return the tangent of *x* (in radians)."""
+    return math.tan(x)

--- a/calculator/integration.py
+++ b/calculator/integration.py
@@ -1,0 +1,23 @@
+"""Numerical integration utilities."""
+
+from typing import Callable
+
+
+def integrate(func: Callable[[float], float], a: float, b: float, n: int = 1000) -> float:
+    """Approximate the definite integral of *func* from *a* to *b* using the trapezoidal rule.
+
+    Args:
+        func: Function to integrate.
+        a: Lower bound.
+        b: Upper bound.
+        n: Number of subdivisions. More subdivisions yield a more accurate result.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+
+    h = (b - a) / n
+    total = 0.5 * (func(a) + func(b))
+    for i in range(1, n):
+        x = a + i * h
+        total += func(x)
+    return total * h

--- a/calculator/plotting.py
+++ b/calculator/plotting.py
@@ -1,0 +1,37 @@
+"""Plotting utilities using matplotlib."""
+
+from typing import Callable
+
+def plot_function(func: Callable[[float], float], start: float, end: float, num_points: int = 100, filename: str | None = None):
+    """Plot *func* over the interval [start, end].
+
+    Args:
+        func: Function to plot.
+        start: Start of the interval.
+        end: End of the interval.
+        num_points: Number of points to sample.
+        filename: If provided, the plot is saved to this file.
+    Returns:
+        The matplotlib figure object.
+
+    Raises:
+        ImportError: If ``matplotlib`` or ``numpy`` are not available.
+    """
+    if num_points <= 1:
+        raise ValueError("num_points must be greater than 1")
+    try:
+        import numpy as np
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError("matplotlib and numpy are required for plotting") from exc
+
+    x = np.linspace(start, end, num_points)
+    y = [func(val) for val in x]
+    fig, ax = plt.subplots()
+    ax.plot(x, y)
+    ax.set_xlabel("x")
+    ax.set_ylabel("f(x)")
+    ax.set_title("Function plot")
+    if filename:
+        fig.savefig(filename)
+    return fig

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -1,0 +1,23 @@
+import math
+
+import pytest
+
+from calculator import add, subtract, multiply, divide, sin, cos, tan
+
+
+def test_basic_operations():
+    assert add(2, 3) == 5
+    assert subtract(5, 2) == 3
+    assert multiply(4, 3) == 12
+    assert divide(10, 2) == 5
+
+
+def test_divide_by_zero():
+    with pytest.raises(ValueError):
+        divide(1, 0)
+
+
+def test_trigonometry():
+    assert math.isclose(sin(math.pi / 2), 1.0, rel_tol=1e-9)
+    assert math.isclose(cos(0), 1.0, rel_tol=1e-9)
+    assert math.isclose(tan(0), 0.0, rel_tol=1e-9)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,13 @@
+import math
+
+from calculator import integrate
+
+
+def test_integrate_linear():
+    result = integrate(lambda x: x, 0, 1, n=1000)
+    assert math.isclose(result, 0.5, rel_tol=1e-3)
+
+
+def test_integrate_sine():
+    result = integrate(math.sin, 0, math.pi, n=1000)
+    assert math.isclose(result, 2.0, rel_tol=1e-3)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,25 @@
+import pytest
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")  # Use non-interactive backend for tests
+    import matplotlib.pyplot as plt
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+    plt = None
+
+from calculator import plot_function
+
+
+@pytest.mark.skipif(not MATPLOTLIB_AVAILABLE, reason="matplotlib not installed")
+def test_plot_function_returns_figure():
+    fig = plot_function(lambda x: x ** 2, 0, 1, num_points=10)
+    assert fig.axes
+    ax = fig.axes[0]
+    line = ax.lines[0]
+    x_data = line.get_xdata()
+    y_data = line.get_ydata()
+    assert x_data[0] == 0 and x_data[-1] == 1
+    assert y_data[0] == 0 and y_data[-1] == 1
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- Implement algebra module with basic and trigonometric operations
- Add numerical integration utilities
- Provide plotting functionality with optional matplotlib dependency
- Include unit tests for each calculator module

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77d05ed2c832589b111274db69c0e